### PR TITLE
fix: Fix GitHub README for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ USER appuser
 
 EXPOSE 5000
 
-CMD ["npm", "start"]
+CMD ["npm", "run", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN npm ci
 COPY . .
 
 # Rebuild bcrypt
-RUN npm rebuild bcrypt --build-from-source
+RUN npm rebuild bcrypt --build-from-source \
+    && npm install -g nodemon
 
 # Create a non-root user
 RUN addgroup -S appgroup \

--- a/README.md
+++ b/README.md
@@ -118,11 +118,14 @@ If you're running the service locally without Docker:
 
 ```bash
 npm install
+
+# Make sure Nodemon is enabled globally
+npm install -g nodemon
 ```
 
 ### Run the Server
 ```bash
-npm start
+npm run dev
 ```
 
 ## Deployment


### PR DESCRIPTION
- Enable `nodemon` in the app `Dockerfile`.
- Add `nodemon` to the `README`.